### PR TITLE
Copy query parameters to proxy request

### DIFF
--- a/src/Proxy/HttpRequestExtensions.cs
+++ b/src/Proxy/HttpRequestExtensions.cs
@@ -4,6 +4,15 @@ internal static class HttpRequestExtensions
 {
     public static async Task<HttpRequestMessage> RewriteProxyRequestAsync( this HttpRequest request, string url )
     {
+        // copy query parameters
+        if ( request.QueryString.HasValue )
+        {
+            url = string.Concat(
+                url,
+                request.QueryString.ToString()
+            );
+        }
+
         var message = new HttpRequestMessage( new HttpMethod( request.Method ), url );
 
         // copy headers


### PR DESCRIPTION
Fixes #2 

Bellow is the result of a local execution on the gateway to invoke a function that spits out the query parameters.

```bash
$ rest post "localhost:8080?foo=bar"
Warning: data argument is empty.
[
  {
    "key": "foo",
    "value": "bar"
  }
]
```
