### PR TITLE
Forwarding response headers

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+temp=$(mktemp "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+
+echo $GITHUB_TOKEN > $temp
+
 if [ -z "$1" ]; then
     echo "Tag not supplied. Image won't be published."
 
-    docker buildx build --secret id=nuget.config,src=$HOME/.nuget/NuGet/NuGet.Config --platform linux/amd64,linux/arm64 -t faas-gateway .
+    docker buildx build --secret id=GITHUB_TOKEN,src=$temp --platform linux/amd64,linux/arm64 -t faas-gateway .
 else
-    docker buildx build --secret id=nuget.config,src=$HOME/.nuget/NuGet/NuGet.Config --push --platform linux/amd64,linux/arm64 -t goncalooliveira/faas-gateway:$1 .
+    docker buildx build --secret id=GITHUB_TOKEN,src=$temp --push --platform linux/amd64,linux/arm64 -t goncalooliveira/faas-gateway:$1 .
 fi
+
+rm $temp

--- a/src/AspNetCore/CustomHttpResult.cs
+++ b/src/AspNetCore/CustomHttpResult.cs
@@ -2,12 +2,22 @@ internal class CustomHttpResult : IResult
 {
     private readonly int statusCode;
     private readonly string? contentType;
+    private readonly System.Net.Http.Headers.HttpResponseHeaders headers;
     private readonly ReadOnlyMemory<byte> content;
 
-    public CustomHttpResult( int statusCode, string? contentType, ReadOnlyMemory<byte> content )
+    private readonly string[] unsafeHeaders = new string[]
+    {
+        "Content-Type",
+        "Content-Length",
+        "Date",
+        "Transfer-Encoding"
+    };
+
+    public CustomHttpResult( int statusCode, string? contentType, System.Net.Http.Headers.HttpResponseHeaders headers, ReadOnlyMemory<byte> content )
     {
         this.statusCode = statusCode;
         this.contentType = contentType;
+        this.headers = headers;
         this.content = content;
     }
 
@@ -16,6 +26,20 @@ internal class CustomHttpResult : IResult
         httpContext.Response.StatusCode = statusCode;
         httpContext.Response.ContentType = contentType ?? string.Empty;
         httpContext.Response.ContentLength = content.Length;
+
+        foreach ( var header in headers )
+        {
+            if ( unsafeHeaders.Contains( header.Key, StringComparer.OrdinalIgnoreCase ) )
+            {
+                continue;
+            }
+
+            try
+            {
+                httpContext.Response.Headers.Add( header.Key, header.Value.ToArray() );
+            }
+            catch {}
+        }
 
         await httpContext.Response.BodyWriter.WriteAsync( content );
     }

--- a/src/Proxy/ProxyRoutes.cs
+++ b/src/Proxy/ProxyRoutes.cs
@@ -68,10 +68,12 @@ internal static class ProxyRoutes
 
             var content = await response.Content.ReadAsByteArrayAsync();
             var contentType = response.Content.Headers.ContentType?.ToString();
+            var headers = response.Headers;
 
             return new CustomHttpResult(
                   statusCode: (int)response.StatusCode
                 , contentType: contentType
+                , headers: headers
                 , content: new ReadOnlyMemory<byte>( content )
             );
         }


### PR DESCRIPTION
An invoked function headers are not forwarded through the proxy. Some unsafe headers are ignore though, such as `Transfer-Encoding`, as these can cause conflicts on the receiver.