### PR TITLE
Added missing function call target

### DIFF
--- a/src/Proxy/Async/FunctionCall.cs
+++ b/src/Proxy/Async/FunctionCall.cs
@@ -1,5 +1,7 @@
 public sealed class FunctionCall
 {
+    public required string Name { get; set; }
+    public required string? Namespace { get; set; }
     public Dictionary<string, string> Arguments { get; set; } = new Dictionary<string, string>();
     public Dictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
     public IEnumerable<byte> Content { get; set; } = Enumerable.Empty<byte>();

--- a/src/Proxy/Async/HttpRequestFunctionCallExtensions.cs
+++ b/src/Proxy/Async/HttpRequestFunctionCallExtensions.cs
@@ -2,7 +2,11 @@ internal static class HttpRequestFunctionCallExtensions
 {
     public static async Task<FunctionCall> CopyToFunctionCallAsync( this HttpRequest httpRequest, string ns, string name )
     {
-        var invoke = new FunctionCall();
+        var invoke = new FunctionCall
+        {
+            Namespace = ns,
+            Name = name
+        };
 
         var path = httpRequest.GetPathWithoutProxy( ns, name );
 


### PR DESCRIPTION
The function's `name` and `namespace` were missing from the serialization object.